### PR TITLE
Placeholder for ss14 roadmap

### DIFF
--- a/src/tree.dot
+++ b/src/tree.dot
@@ -53,7 +53,7 @@ digraph G {
 				fontcolor = "blue"
 				decorate=true
 				label  = <<b><u>GitHub source <br/>repository</u></b>>,
-				URL    = "https://github.com/CthulhuOnIce/SS13-Codebases",
+				URL    = "https://github.com/Noliuss/SS14-Codebases",
 				width  = 1.4,
 				height = .8
 			]
@@ -66,168 +66,20 @@ digraph G {
 
 		}
 
-		//
-		subgraph cluster_not_byond
-		{
-			/// Attributes ///
-			label    = "This builds does not running on BYOND"
-			style    = "dotted"
-			//rankdir  = "LB"
-			//compound = false
-			//rank     = same
-
-			node [
-				shape    = rectangle,
-				//fontsize = 14,
-				//width    = 3.5
-				//height   = .08
-				minlen   = 1
-			]
-			edge [
-				constraint = false
-				dir = left
-			]
-
-			/// Nodes ///
-			"Space Station 14" // added by: CthulhuOnIce
-			"UnityStation" // added by: CthulhuOnIce
-			"Lili station" // added by: Gesugao-san
-
-			/// Edges ///
-			"Lili station" -> "cbay" // added by: Gesugao-san
-			"SS3D"         -> "RE:SS3D" // added by: CthulhuOnIce
-
-		}
-
 		/// Attributes ///
-		label    = "SS13 Codebases Circa Mid 2021"
+		label    = "SS14 Codebases Roadmap"
 		labelloc = "top"
 		style    = "dotted"
 		//rankdir = "TB"
 		//edge [constraint = true]
 
 		/// Nodes ///
-		"Goonstation" [shape = rectangle, color = blue] // added by: CthulhuOnIce
-		"/tg/Station (GPLv3)" [shape = rectangle, color = blue] // added by: CthulhuOnIce
-		"/tg/Station (AGPL)" [shape = rectangle, color = blue] // added by: CthulhuOnIce
-		"BayStation (GPL)" [shape = rectangle, color = blue] // added by: CthulhuOnIce
-		"BayStation (AGPL)" [shape = rectangle, color = blue] // added by: CthulhuOnIce
+		"Space Station 14" [shape = rectangle, color = blue] // added by: noliuss
+		"Einstein Engines (AGPLv3)" [shape = rectangle, color = blue] // added by: noliuss
 
 		/// Edges ///
-		"/tg/stalker"                   -> "Call of Flesh" // added by: Gesugao-san
-		"/tg/Station (AGPL)"            -> "/tg/stalker" // added by: Gesugao-san
-		"/tg/Station (AGPL)"            -> "Apollo Station" // added by: CthulhuOnIce
-		"/tg/Station (AGPL)"            -> "BeeStation" // added by: CthulhuOnIce
-		"/tg/Station (AGPL)"            -> "Citadel Main" // added by: CthulhuOnIce
-		"/tg/Station (AGPL)"            -> "Fallout 13" // added by: CthulhuOnIce
-		"/tg/Station (AGPL)"            -> "FTL13" // added by: CthulhuOnIce
-		"/tg/Station (AGPL)"            -> "HippieStation" // added by: CthulhuOnIce
-		"/tg/Station (AGPL)"            -> "Mojave Sun" // added by: CthulhuOnIce
-		"/tg/Station (AGPL)"            -> "OracleStation" // added by: CthulhuOnIce
-		"/tg/Station (AGPL)"            -> "Sigma" // added by: Gesugao-san
-		"/tg/Station (AGPL)"            -> "Star Trek 13" // added by: CthulhuOnIce
-		"/tg/Station (AGPL)"            -> "Sunset Station" // added by: CthulhuOnIce
-		"/tg/Station (AGPL)"            -> "Toolbox Station" // added by: CthulhuOnIce
-		"/tg/Station (AGPL)"            -> "WaspStation" // added by: CthulhuOnIce
-		"/tg/Station (AGPL)"            -> "YogStation" // added by: CthulhuOnIce
-		"/tg/Station (GPLv3)"           -> "/tg/Station (AGPL)" [color = red] // added by: CthulhuOnIce
-		"/tg/Station (GPLv3)"           -> "Archangel" // added by: CthulhuOnIce
-		"/tg/Station (GPLv3)"           -> "BayStation (GPL)" // added by: CthulhuOnIce
-		"/tg/Station (GPLv3)"           -> "FacePunch" // added by: CthulhuOnIce
-		"/tg/Station (GPLv3)"           -> "FreeTG Station" // added by: Gesugao-san
-		"/tg/Station (GPLv3)"           -> "HippieStation (Old)" // added by: CthulhuOnIce
-		"/tg/Station (GPLv3)"           -> "NTStation" // added by: CthulhuOnIce
-		"/tg/Station (GPLv3)"           -> "Traitor Death Match" // added by: CthulhuOnIce
-		"/tg/Station (GPLv3)"           -> "YogStation (Old)" // added by: CthulhuOnIce
-		"AEIOU"                         -> "Eclipse Station" [color = red] // added by: CthulhuOnIce
-		"Aurora (Old)"                  -> "Aurora Station" [color = red] // added by: CthulhuOnIce
-		"Ava's Battlegrounds"           -> "No Mans's Land" // added by: CthulhuOnIce
-		"BayStation (AGPL)"             -> "Aurora Station" // added by: CthulhuOnIce
-		"BayStation (AGPL)"             -> "CEV Eris" // added by: CthulhuOnIce
-		"BayStation (AGPL)"             -> "Dead Space 13" // added by: CthulhuOnIce
-		"BayStation (AGPL)"             -> "Europa Station" // added by: CthulhuOnIce
-		"BayStation (AGPL)"             -> "Halo: Space Station Evolved" // added by: CthulhuOnIce
-		"BayStation (AGPL)"             -> "Interbay" // added by: CthulhuOnIce
-		"BayStation (AGPL)"             -> "KaiserBay" // added by: Gesugao-san
-		"BayStation (AGPL)"             -> "Nebula" // added by: Gesugao-san
-		"BayStation (AGPL)"             -> "Persistence" // added by: CthulhuOnIce
-		"BayStation (AGPL)"             -> "Polaris" // added by: CthulhuOnIce
-		"BayStation (AGPL)"             -> "SCP-13" // added by: CthulhuOnIce
-		"BayStation (AGPL)"             -> "Urist McStation" // added by: CthulhuOnIce
-		"BayStation (GPL)"              -> "/vg/Station" // added by: CthulhuOnIce
-		"BayStation (GPL)"              -> "Aurora (Old)" // added by: CthulhuOnIce
-		"BayStation (GPL)"              -> "BayStation (AGPL)" [color = red] // added by: CthulhuOnIce
-		"BayStation (GPL)"              -> "BestRP" // added by: CthulhuOnIce
-		"BayStation (GPL)"              -> "Colonial Marines (CM)" // added by: CthulhuOnIce
-		"BayStation (GPL)"              -> "Paradise" // added by: CthulhuOnIce
-		"BayStation (GPL)"              -> "RocketStation42" // added by: CthulhuOnIce
-		"BayStation (GPL)"              -> "Tau Ceti" // added by: CthulhuOnIce
-		"BayStation (Luna)"             -> "Lifeweb" // added by: CthulhuOnIce
-		"BeeStation"                    -> "Austation" // added by: CthulhuOnIce
-		"BeeStation"                    -> "NSV13" // added by: CthulhuOnIce
-		"BestRP"                        -> "Unbound Travels" // added by: Gesugao-san
-		"Boomer Station"                -> "White Sands" [color = red] // added by: Gesugao-san
-		"Call of Flesh"                 -> "Stalker Project" // added by: Gesugao-san
-		"CEV Eris"                      -> "InterStation-Two" // added by: CthulhuOnIce
-		"CEV Eris"                      -> "NEV Northern Light" // added by: Gesugao-san
-		"CEV Eris"                      -> "Soujurn Station"
-		"Citadel Main"                  -> "BurgerStation 13" // added by: CthulhuOnIce
-		"Citadel Main"                  -> "HyperStation" // added by: CthulhuOnIce
-		"Citadel Main"                  -> "Skyrat 13 (Old)" // added by: CthulhuOnIce Updated by ORCACommander
-		"Skyrat 13 (Old)"				-> "Skyrat Main" [color = red] // Updated By ORCACommander
-		"/tg/Station (AGPL)"			-> "Skyrat Main" // added by: ORCACommander
-		"Skyrat Main"					-> "Tannhauser Gate" //added: By ORCACommander
-		"Skyrat Main"					-> "Nebula Station 13" // Added By: ORCACommander
-		"Skyrat Main"					-> "Fluffy Frontier" // Added By: ORCACommander
-		"Colonial Marines (CM)"         -> "DM;CA" // added by: CthulhuOnIce
-		"DM;CA"                         -> "TerraGov Marine Corps (TGMC)" [color = red] // added by: CthulhuOnIce
-		"FacePunch"                     -> "Corporate Mercenaries" // added by: CthulhuOnIce
-		"Fallout 13"                    -> "Desert Rose" // added by: CthulhuOnIce
-		"FTL13 (Old)"                   -> "FTL13" [color = red] // added by: CthulhuOnIce
-		"Goonstation (2009 Public SVN)" -> "BayStation (Pre-r4407)" // added by: Gesugao-san
-		"Goonstation (2016 Release)"    -> "Goonstation (2020 Release)" [color = red] // added by: CthulhuOnIce
-		"Goonstation (2016 Release)"    -> "T/Goonstation" // added by: CthulhuOnIce
-		"Goonstation (Open Source)"     -> "BeeStation Clover" // added by: Gesugao-san
-		"Goonstation"                   -> "Goonstation (2009 Public SVN)" [color = red] // added by: Gesugao-san
-		"Goonstation"                   -> "Goonstation (2016 Release)" [color = red] // added by: CthulhuOnIce
-		"Goonstation"                   -> "Goonstation (Open Source)" [color = red] // added by: CthulhuOnIce
-		"Goonstation"                   -> "Revision 4407 (r4407)" [color = red] // added by: CthulhuOnIce
-		"HippieStation (Old)"           -> "HippieStation" [color = red] // added by: Gesugao-san
-		"Interbay 1.0"                  -> "Interbay 2.0" // added by: Gesugao-san
-		"Interbay 2.0"                  -> "Interbay 3.0" // added by: Gesugao-san
-		"Interbay"                      -> "Cadia Station" // added by: Gesugao-san
-		"Interbay"                      -> "Interpost Hague" // added by: CthulhuOnIce
-		"Interbay"                      -> "Samosbor 13" // added by: Gesugao-san
-		"InterHippie"                   -> "Interbay 1.0" // added by: Gesugao-san
-		"Interpost Hague"               -> "InterHippie" // added by: Gesugao-san
-		"Interpost Hague"               -> "Interpost: Redux" // added by: Gesugao-san
-		"InterStation-Two"              -> "Ava's Battlegrounds" // added by: CthulhuOnIce
-		"Lebensraum"                    -> "Civilization 13" // added by: CthulhuOnIce
-		"No Mans's Land"                -> "Lebensraum" // added by: CthulhuOnIce
-		"NTStation"                     -> "D20 Station" // added by: CthulhuOnIce
-		"OpenSS13"                      -> "BayStation (OpenSS13)"
-		"Paradise"                      -> "ATMTA Station" // added by: Gesugao-san
-		"Paradise"                      -> "Persistence SS13 (Old)" // added by: CthulhuOnIce
-		"Persistence SS13 (Old)"        -> "Persistence" [color = red] // added by: Gesugao-san
-		"Polaris"                       -> "V.O.R.E. Station" // added by: CthulhuOnIce
-		"Polaris"                       -> "World Server" // added by: CthulhuOnIce
-		"Revision 4407 (r4407)"         -> "/tg/Station (GPLv3)" // added by: CthulhuOnIce, edited: Gesugao-san
-		"Revision 4407 (r4407)"         -> "BayStation (Luna)" // added by: CthulhuOnIce
-		"Revision 4407 (r4407)"         -> "D2K5" // added by: CthulhuOnIce
-		"Revision 4407 (r4407)"         -> "Mars Station 42" // added by: CthulhuOnIce
-		"Soujurn Station"               -> "Navarro" // added by: Gesugao-san
-		"SS13 (Pre Open)"               -> "Goonstation" // added by: CthulhuOnIce
-		"SS13 (Pre Open)"               -> "OpenSS13" [label = "[Source Decompilation]"] // added by: CthulhuOnIce
-		"Stalker Project"               -> "Ashen Sky" // added by: Gesugao-san
-		"Star Trek 13"                  -> "Deep Space 13" [color = red] // added by: CthulhuOnIce
-		"Unbound Travels"               -> "Aphelion Project" // added by: Gesugao-san
-		"V.O.R.E. Station"              -> "AEIOU" // added by: CthulhuOnIce
-		"V.O.R.E. Station"              -> "Citadel RP" // added by: CthulhuOnIce
-		"V.O.R.E. Station"              -> "Yawn Wider" // added by: CthulhuOnIce
-		"WaspStation"                   -> "Boomer Station" [color = red] // added by: CthulhuOnIce
-		"Yawn Wider"                    -> "CHOMPstation" // added by: CthulhuOnIce
-		"YogStation (Old)"              -> "YogStation" [color = red] // added by: CthulhuOnIce
-		"YogStation"                    -> "FTL13 (Old)" // added by: CthulhuOnIce, edited: quardbreak
-		"YogStation"                    -> "Fulpstation" // added by: CthulhuOnIce
+		"Space Station 14"           -> "Nyanotrasen" // added by: noliuss
+		"Space Station 14"           -> "Delta-V" [color = red] // added by: noliuss
+		"Delta-V"                    -> "Einstein Engines (AGPLv3)" // added by: noliuss
 	}
 }


### PR DESCRIPTION
 Removed: All SS13 repos
 
 Added: Main SS14 repo, Delta-V and Einstein Engines